### PR TITLE
Delete addresses from restaurants#show page

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -17,6 +17,14 @@ class AddressesController < ApplicationController
     end
   end
 
+  def destroy
+    address = Address.find(params[:id])
+    @restaurant = address.restaurant_id
+    @address = address.destroy
+
+    redirect_to restaurant_path(@restaurant)
+  end
+
   private
 
   def address_params

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -13,6 +13,7 @@
       <% @restaurant.addresses.each do |address| %>
         <li>
           <%= full_address(address) %>
+          <%= link_to "DEL", destroy_restaurant_address_path(@restaurant, address.id), method: :delete %>
         </li>
       <% end %>
     </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,6 @@ Rails.application.routes.draw do
     resources :addresses
   end
 
+  delete '/restaurants/:restaurant_id/addresses/:id', to: 'addresses#destroy', as: :destroy_restaurant_address
+
 end


### PR DESCRIPTION
Addition of a delete button next to each address on the restaurants#show page.
I wanted to see if this was implemented properly, routing was a bit confusing. I could not figure out how to access the resourceful route DELETE /restaurants/:restaurant_id/addresses/:id(.:format), so i created a new route destroy_restaurant_address_path. Let me know if i should have used a different method to make this work.